### PR TITLE
Add uvx support for one-line execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,32 @@ https://github.com/user-attachments/assets/1b5f42f7-85d5-4918-aca4-d38413b0e82b
 ## 📦 Installation
 
 ### Prerequisites
-- UV package manager (recommended)
 - Python 3.10 or higher
-- Git
 - Access to a Proxmox server with API token credentials
 
 Before starting, ensure you have:
 - [ ] Proxmox server hostname or IP
 - [ ] Proxmox API token (see [API Token Setup](#proxmox-api-token-setup))
-- [ ] UV installed (`pip install uv`)
 
-### Option 1: Quick Install (Recommended)
+### Option 1: Quick Start with uvx (Easiest)
+
+For immediate use without installation:
+```bash
+# Install uvx if you haven't already
+pip install uv
+
+# Create configuration file (see Configuration section below)
+mkdir -p proxmox-config
+# Copy and edit config.example.json to proxmox-config/config.json
+
+# Set configuration path and run
+export PROXMOX_MCP_CONFIG="$(pwd)/proxmox-config/config.json"
+uvx proxmox-mcp
+```
+
+### Option 2: Development Install
+
+For development or customization:
 
 1. Clone and set up environment:
    ```bash
@@ -70,7 +85,7 @@ Before starting, ensure you have:
    ```bash
    # Create config directory and copy template
    mkdir -p proxmox-config
-   cp config/config.example.json proxmox-config/config.json
+   cp proxmox-config/config.example.json proxmox-config/config.json
    ```
 
 4. Edit `proxmox-config/config.json`:
@@ -133,6 +148,16 @@ Before starting, ensure you have:
 
 
 ## 🚀 Running the Server
+
+### Quick Start with uvx (Recommended)
+The easiest way to run the server is with uvx:
+```bash
+# Set your configuration file path
+export PROXMOX_MCP_CONFIG="/path/to/your/proxmox-config/config.json"
+
+# Run the server with uvx (no installation needed)
+uvx proxmox-mcp
+```
 
 ### Development Mode
 For testing and development:

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -142,10 +142,21 @@ class ProxmoxMCPServer:
             self.logger.error(f"Server error: {e}")
             sys.exit(1)
 
-if __name__ == "__main__":
+def main() -> None:
+    """Main entry point for the Proxmox MCP server.
+    
+    This function serves as the primary entry point for uvx and script execution.
+    It handles configuration loading, server initialization, and graceful shutdown.
+    """
     config_path = os.getenv("PROXMOX_MCP_CONFIG")
     if not config_path:
-        print("PROXMOX_MCP_CONFIG environment variable must be set")
+        print("Error: PROXMOX_MCP_CONFIG environment variable must be set")
+        print("\nTo run the Proxmox MCP server:")
+        print("1. Set the configuration file path:")
+        print("   export PROXMOX_MCP_CONFIG=/path/to/config.json")
+        print("2. Run the server:")
+        print("   uvx proxmox-mcp")
+        print("\nFor more information, see the README.md file.")
         sys.exit(1)
     
     try:
@@ -157,3 +168,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Error: {e}")
         sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add uvx support enabling one-line execution: `uvx proxmox-mcp`
- Update README with uvx as primary installation method
- Improve error messaging with helpful setup instructions

## Changes
- **Add main() function**: Proper entry point for uvx/pip script execution  
- **Enhanced documentation**: uvx quick start instructions as the recommended method
- **Better error handling**: Clear setup guidance when configuration is missing
- **Backward compatibility**: Maintains existing direct script execution support
- **Bug fix**: Correct config template path reference in README

## Usage
After this change, users can run the server with:
```bash
export PROXMOX_MCP_CONFIG="/path/to/config.json"
uvx proxmox-mcp
```

## Test plan
- [x] Verify Python syntax is valid
- [x] Confirm entry point configuration in pyproject.toml is correct
- [x] Test backward compatibility with direct execution
- [x] Validate improved error messages guide users properly

The pyproject.toml already had the correct `[project.scripts]` configuration, so no changes were needed there.