### PR TITLE
Fix Python version constraint and MCP SDK dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "proxmox-mcp"
 version = "0.1.0"
 description = "A Model Context Protocol server for interacting with Proxmox hypervisors"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Kevin", email = "kevin@example.com"}
 ]
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp @ git+https://github.com/modelcontextprotocol/python-sdk.git",
+    "mcp>=1.0.0,<1.7.0",
     "proxmoxer>=2.0.1,<3.0.0",
     "requests>=2.31.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -142,12 +142,12 @@ class ProxmoxMCPServer:
             self.logger.error(f"Server error: {e}")
             sys.exit(1)
 
-if __name__ == "__main__":
+def main() -> None:
     config_path = os.getenv("PROXMOX_MCP_CONFIG")
     if not config_path:
         print("PROXMOX_MCP_CONFIG environment variable must be set")
         sys.exit(1)
-    
+
     try:
         server = ProxmoxMCPServer(config_path)
         server.start()
@@ -157,3 +157,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Error: {e}")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Bump `requires-python` from `>=3.9` to `>=3.10` — the `mcp` SDK requires Python 3.10+, making the previous constraint unsatisfiable
- Replace unstable `mcp @ git+...` dependency with stable `mcp>=1.0.0,<1.7.0` — the git HEAD removed `mcp.server.fastmcp` module, breaking the server import
- Add `main()` entry point function to `server.py` to match the `[project.scripts]` config in `pyproject.toml`
