### PR TITLE
Skip unreachable nodes in get_vms instead of failing

### DIFF
--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -77,7 +77,11 @@ class VMTools(ProxmoxTool):
             result = []
             for node in self.proxmox.nodes.get():
                 node_name = node["node"]
-                vms = self.proxmox.nodes(node_name).qemu.get()
+                try:
+                    vms = self.proxmox.nodes(node_name).qemu.get()
+                except Exception:
+                    self.logger.warning(f"Skipping node {node_name}: unable to connect")
+                    continue
                 for vm in vms:
                     vmid = vm["vmid"]
                     # Get VM config for CPU cores


### PR DESCRIPTION
Previously, a single offline node caused the entire `get_vms` tool to fail with `595 No route to host`.

- Wrap per-node `qemu.get()` call in try/except so offline/unreachable nodes are skipped gracefully
- VMs on reachable nodes are now returned normally; unreachable nodes are logged and skipped

