### PR TITLE
Skip unreachable nodes in get_vms instead of failing

### DIFF
--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -77,7 +77,11 @@ class VMTools(ProxmoxTool):
             result = []
             for node in self.proxmox.nodes.get():
                 node_name = node["node"]
-                vms = self.proxmox.nodes(node_name).qemu.get()
+                try:
+                    vms = self.proxmox.nodes(node_name).qemu.get()
+                except Exception:
+                    self.logger.warning(f"Skipping node {node_name}: unable to connect")
+                    continue
                 for vm in vms:
                     vmid = vm["vmid"]
                     # Get VM config for CPU cores


### PR DESCRIPTION
When a node is offline, proxmox.nodes(node).qemu.get() throws a connection error that bubbles up and fails the entire get_vms call. Wrap the per-node VM query in try/except so offline nodes are skipped gracefully while VMs on reachable nodes are still returned.