### PR TITLE
Added a tool that retrieves network interface information (IP address…

### DIFF
--- a/src/proxmox_mcp/formatting/templates.py
+++ b/src/proxmox_mcp/formatting/templates.py
@@ -209,5 +209,47 @@ class ProxmoxTemplates:
         resources = status.get('resources', [])
         if resources:
             result.append(f"  • Resources: {len(resources)}")
-        
+
+        return "\n".join(result)
+
+    @staticmethod
+    def network_interfaces(data: List[Dict[str, Any]]) -> str:
+        """Template for VM network interfaces output.
+
+        Args:
+            data: List of VM data dictionaries with interfaces
+
+        Returns:
+            Formatted network interfaces string
+        """
+        if not data:
+            return f"{ProxmoxTheme.RESOURCES['network']} No network interfaces found"
+
+        result = [f"{ProxmoxTheme.RESOURCES['network']} VM Network Interfaces"]
+
+        for vm in data:
+            result.extend([
+                "",
+                f"{ProxmoxTheme.RESOURCES['vm']} {vm.get('name', 'Unknown')} (ID: {vm['vmid']}) on {vm['node']}"
+            ])
+
+            if vm.get("error"):
+                result.append(f"    ⚠️ Error: {vm['error']}")
+                continue
+
+            interfaces = vm.get("interfaces", [])
+            if not interfaces:
+                result.append("    No interfaces found")
+                continue
+
+            for iface in interfaces:
+                result.extend([
+                    f"    {iface.get('name', 'unknown')}",
+                    f"      • MAC: {iface.get('mac', 'N/A')}"
+                ])
+                if iface.get("ipv4"):
+                    result.append(f"      • IPv4: {', '.join(iface['ipv4'])}")
+                if iface.get("ipv6"):
+                    result.append(f"      • IPv6: {', '.join(iface['ipv6'])}")
+
         return "\n".join(result)

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -37,6 +37,7 @@ from .tools.definitions import (
     GET_NODE_STATUS_DESC,
     GET_VMS_DESC,
     EXECUTE_VM_COMMAND_DESC,
+    GET_VM_NETWORK_INTERFACES_DESC,
     GET_CONTAINERS_DESC,
     GET_STORAGE_DESC,
     GET_CLUSTER_STATUS_DESC
@@ -105,6 +106,14 @@ class ProxmoxMCPServer:
         ):
             return await self.vm_tools.execute_command(node, vmid, command)
 
+        @self.mcp.tool(description=GET_VM_NETWORK_INTERFACES_DESC)
+        def get_vm_network_interfaces(
+            targets: Annotated[Optional[List[dict]], Field(default=None, description="List of VM targets: [{'node': 'pve1', 'vmid': '100'}, ...]")] = None,
+            node: Annotated[Optional[str], Field(default=None, description="Host node name (e.g. 'pve1'). Omit for all nodes.")] = None,
+            vmid: Annotated[Optional[str], Field(default=None, description="VM ID (e.g. '100'). Omit for all running VMs.")] = None
+        ):
+            return self.vm_tools.get_vm_network_interfaces(targets, node, vmid)
+
         # Storage tools
         @self.mcp.tool(description=GET_STORAGE_DESC)
         def get_storage():
@@ -145,15 +154,15 @@ class ProxmoxMCPServer:
 if __name__ == "__main__":
     config_path = os.getenv("PROXMOX_MCP_CONFIG")
     if not config_path:
-        print("PROXMOX_MCP_CONFIG environment variable must be set")
+        print("PROXMOX_MCP_CONFIG environment variable must be set", file=sys.stderr)
         sys.exit(1)
     
     try:
         server = ProxmoxMCPServer(config_path)
         server.start()
     except KeyboardInterrupt:
-        print("\nShutting down gracefully...")
+        print("\nShutting down gracefully...", file=sys.stderr)
         sys.exit(0)
     except Exception as e:
-        print(f"Error: {e}")
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/proxmox_mcp/tools/base.py
+++ b/src/proxmox_mcp/tools/base.py
@@ -68,6 +68,8 @@ class ProxmoxTool:
             formatted = ProxmoxTemplates.storage_list(data)
         elif resource_type == "containers":
             formatted = ProxmoxTemplates.container_list(data)
+        elif resource_type == "network_interfaces":
+            formatted = ProxmoxTemplates.network_interfaces(data)
         elif resource_type == "cluster":
             formatted = ProxmoxTemplates.cluster_status(data)
         else:

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -32,6 +32,25 @@ command* - Shell command to run (e.g. 'uname -a')
 Example:
 {"success": true, "output": "Linux vm1 5.4.0", "exit_code": 0}"""
 
+GET_VM_NETWORK_INTERFACES_DESC = """Get network interface information for VMs via QEMU guest agent.
+
+Returns IP addresses, MAC addresses, and interface names reported by the guest agent.
+Requires VMs to be running with QEMU guest agent installed.
+
+Parameters:
+targets - List of VM targets: [{"node": "pve1", "vmid": "100"}, ...]. Takes priority if provided.
+node - Host node name (e.g. 'pve1'). If omitted, queries all nodes.
+vmid - VM ID number (e.g. '100'). If omitted, queries all running VMs.
+
+Examples:
+  Specific VMs: targets=[{"node": "pve1", "vmid": "100"}, {"node": "pve2", "vmid": "101"}]
+  Single VM: node="pve1", vmid="100"
+  All VMs on node: node="pve1"
+  All VMs cluster-wide: (no parameters)
+
+Output:
+[{"vmid": "100", "node": "pve1", "name": "ubuntu", "interfaces": [...]}]"""
+
 # Container tool descriptions
 GET_CONTAINERS_DESC = """List all LXC containers across the cluster with their status and configuration.
 

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -13,10 +13,10 @@ This module provides tools for managing and interacting with Proxmox VMs:
 The tools implement fallback mechanisms for scenarios where
 detailed VM information might be temporarily unavailable.
 """
-from typing import List
+from typing import List, Optional
 from mcp.types import TextContent as Content
 from .base import ProxmoxTool
-from .definitions import GET_VMS_DESC, EXECUTE_VM_COMMAND_DESC
+from .definitions import GET_VMS_DESC, EXECUTE_VM_COMMAND_DESC, GET_VM_NETWORK_INTERFACES_DESC
 from .console.manager import VMConsoleManager
 
 class VMTools(ProxmoxTool):
@@ -150,3 +150,162 @@ class VMTools(ProxmoxTool):
             return [Content(type="text", text=formatted)]
         except Exception as e:
             self._handle_error(f"execute command on VM {vmid}", e)
+
+    def get_vm_network_interfaces(
+        self,
+        targets: Optional[List[dict]] = None,
+        node: Optional[str] = None,
+        vmid: Optional[str] = None
+    ) -> List[Content]:
+        """Get network interface information for VM(s) via QEMU guest agent.
+
+        Uses the guest agent's network-get-interfaces capability to retrieve
+        IP addresses and MAC addresses. This does not require guest-exec
+        permissions, only the basic guest agent to be running.
+
+        Args:
+            targets: List of VM targets [{"node": "pve1", "vmid": "100"}, ...]. Takes priority.
+            node: Host node name (e.g., 'pve1'). If omitted, queries all nodes.
+            vmid: VM ID number (e.g., '100'). If omitted, queries all running VMs.
+
+        Returns:
+            List of Content objects containing formatted network interface info
+
+        Raises:
+            ValueError: If VM is not found or not running
+            RuntimeError: If guest agent query fails
+        """
+        try:
+            results = []
+
+            # targets takes priority if provided
+            if targets:
+                vm_targets = self._validate_targets(targets)
+            else:
+                vm_targets = self._get_vm_targets(node, vmid)
+
+            for target_node, target_vmid, vm_name in vm_targets:
+                vm_result = {
+                    "vmid": target_vmid,
+                    "node": target_node,
+                    "name": vm_name,
+                    "interfaces": [],
+                    "error": None
+                }
+
+                try:
+                    interfaces = self._query_vm_network_interfaces(target_node, target_vmid)
+                    vm_result["interfaces"] = interfaces
+                except Exception as e:
+                    vm_result["error"] = str(e)
+
+                results.append(vm_result)
+
+            return self._format_response(results, "network_interfaces")
+        except Exception as e:
+            self._handle_error("get network interfaces", e)
+
+    def _get_vm_targets(self, node: Optional[str], vmid: Optional[str]) -> List[tuple]:
+        """Get list of (node, vmid, name) tuples to query based on parameters.
+
+        Args:
+            node: Host node name, or None for all nodes
+            vmid: VM ID, or None for all running VMs
+
+        Returns:
+            List of (node, vmid, name) tuples for VMs to query
+        """
+        targets = []
+
+        if node and vmid:
+            # Single VM - get name from API
+            vm_status = self.proxmox.nodes(node).qemu(vmid).status.current.get()
+            targets.append((node, vmid, vm_status.get("name", f"VM {vmid}")))
+        elif node:
+            # All running VMs on specified node
+            vms = self.proxmox.nodes(node).qemu.get()
+            for vm in vms:
+                if vm["status"] == "running":
+                    targets.append((node, str(vm["vmid"]), vm.get("name", f"VM {vm['vmid']}")))
+        else:
+            # All running VMs cluster-wide
+            for n in self.proxmox.nodes.get():
+                node_name = n["node"]
+                vms = self.proxmox.nodes(node_name).qemu.get()
+                for vm in vms:
+                    if vm["status"] == "running":
+                        targets.append((node_name, str(vm["vmid"]), vm.get("name", f"VM {vm['vmid']}")))
+
+        return targets
+
+    def _validate_targets(self, targets: List[dict]) -> List[tuple]:
+        """Validate and convert target list to (node, vmid, name) tuples.
+
+        Args:
+            targets: List of dicts with 'node' and 'vmid' keys
+
+        Returns:
+            List of (node, vmid, name) tuples
+
+        Raises:
+            ValueError: If target format is invalid
+        """
+        validated = []
+        for target in targets:
+            if not isinstance(target, dict):
+                raise ValueError(f"Target must be dict, got {type(target)}")
+
+            node = target.get('node')
+            vmid = target.get('vmid')
+
+            if not node or not vmid:
+                raise ValueError(f"Target must have 'node' and 'vmid': {target}")
+
+            # Get VM name from API
+            try:
+                vm_status = self.proxmox.nodes(str(node)).qemu(str(vmid)).status.current.get()
+                validated.append((str(node), str(vmid), vm_status.get("name", f"VM {vmid}")))
+            except Exception:
+                # Include in results with error rather than failing validation
+                validated.append((str(node), str(vmid), f"VM {vmid}"))
+
+        return validated
+
+    def _query_vm_network_interfaces(self, node: str, vmid: str) -> List[dict]:
+        """Query a single VM's network interfaces via guest agent.
+
+        Args:
+            node: Host node name
+            vmid: VM ID number
+
+        Returns:
+            List of interface dictionaries with name, mac, ipv4, ipv6
+
+        Raises:
+            Exception: If guest agent query fails
+        """
+        agent_endpoint = self.proxmox.nodes(node).qemu(vmid).agent
+        network_data = agent_endpoint("network-get-interfaces").get()
+
+        interfaces = []
+        for iface in network_data.get("result", []):
+            if iface.get("name") == "lo":
+                continue  # Skip loopback
+
+            interface_info = {
+                "name": iface.get("name"),
+                "mac": iface.get("hardware-address"),
+                "ipv4": [],
+                "ipv6": []
+            }
+
+            for addr in iface.get("ip-addresses", []):
+                ip = addr.get("ip-address")
+                if addr.get("ip-address-type") == "ipv4":
+                    interface_info["ipv4"].append(ip)
+                elif addr.get("ip-address-type") == "ipv6":
+                    interface_info["ipv6"].append(ip)
+
+            interfaces.append(interface_info)
+
+        return interfaces


### PR DESCRIPTION
New Tool: **get_vm_network_interfaces**: Retrieves network interface information (IP addresses, MAC addresses) from VMs via the QEMU guest agent. 

Features                                                                                                                                                                      
  - Flexible targeting: Query specific VMs, all VMs on a node, or all VMs cluster-wide                                                                                          
  - Batch queries: New targets parameter accepts a list of node/vmid pairs for efficient multi-VM queries                                                                       
  - Graceful error handling: Per-VM errors are captured inline rather than failing the entire request                                                                           
  - Formatted output: Human-readable display with VM names, interface names, and addresses                                                                                      
