### PR TITLE
test: restore vm_console import compatibility

### DIFF
--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -2,7 +2,18 @@
 Proxmox MCP Server - A Model Context Protocol server for interacting with Proxmox hypervisors.
 """
 
-from .server import ProxmoxMCPServer
+from typing import TYPE_CHECKING
 
 __version__ = "0.1.0"
 __all__ = ["ProxmoxMCPServer"]
+
+if TYPE_CHECKING:
+    from .server import ProxmoxMCPServer
+
+
+def __getattr__(name):
+    if name == "ProxmoxMCPServer":
+        from .server import ProxmoxMCPServer
+
+        return ProxmoxMCPServer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/proxmox_mcp/tools/vm_console.py
+++ b/src/proxmox_mcp/tools/vm_console.py
@@ -1,0 +1,5 @@
+"""Backward-compatible VM console imports."""
+
+from .console.manager import VMConsoleManager
+
+__all__ = ["VMConsoleManager"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test bootstrap helpers for the repository's src/ layout."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_vm_console.py
+++ b/tests/test_vm_console.py
@@ -2,35 +2,54 @@
 Tests for VM console operations.
 """
 
+import asyncio
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from proxmox_mcp.tools.vm_console import VMConsoleManager
+
 
 @pytest.fixture
 def mock_proxmox():
     """Fixture to create a mock ProxmoxAPI instance."""
     mock = Mock()
-    # Setup chained mock calls
     mock.nodes.return_value.qemu.return_value.status.current.get.return_value = {
         "status": "running"
     }
-    mock.nodes.return_value.qemu.return_value.agent.exec.post.return_value = {
-        "out": "command output",
-        "err": "",
-        "exitcode": 0
+
+    exec_endpoint = Mock()
+    exec_endpoint.post.return_value = {"pid": 123}
+
+    status_endpoint = Mock()
+    status_endpoint.get.return_value = {
+        "out-data": "command output",
+        "err-data": "",
+        "exitcode": 0,
+        "exited": 1,
     }
+
+    def agent_endpoint(name):
+        if name == "exec":
+            return exec_endpoint
+        if name == "exec-status":
+            return status_endpoint
+        raise AssertionError(f"Unexpected guest-agent endpoint: {name}")
+
+    mock.nodes.return_value.qemu.return_value.agent.side_effect = agent_endpoint
+    mock.exec_endpoint = exec_endpoint
+    mock.exec_status_endpoint = status_endpoint
     return mock
+
 
 @pytest.fixture
 def vm_console(mock_proxmox):
     """Fixture to create a VMConsoleManager instance."""
     return VMConsoleManager(mock_proxmox)
 
-@pytest.mark.asyncio
-async def test_execute_command_success(vm_console, mock_proxmox):
+
+def test_execute_command_success(vm_console, mock_proxmox):
     """Test successful command execution."""
-    result = await vm_console.execute_command("node1", "100", "ls -l")
+    result = asyncio.run(vm_console.execute_command("node1", "100", "ls -l"))
 
     assert result["success"] is True
     assert result["output"] == "command output"
@@ -38,49 +57,45 @@ async def test_execute_command_success(vm_console, mock_proxmox):
     assert result["exit_code"] == 0
 
     # Verify correct API calls
+    mock_proxmox.nodes.assert_called_with("node1")
     mock_proxmox.nodes.return_value.qemu.assert_called_with("100")
-    mock_proxmox.nodes.return_value.qemu.return_value.agent.exec.post.assert_called_with(
-        command="ls -l"
-    )
+    mock_proxmox.exec_endpoint.post.assert_called_with(command="ls -l")
+    mock_proxmox.exec_status_endpoint.get.assert_called_with(pid=123)
 
-@pytest.mark.asyncio
-async def test_execute_command_vm_not_running(vm_console, mock_proxmox):
+def test_execute_command_vm_not_running(vm_console, mock_proxmox):
     """Test command execution on stopped VM."""
     mock_proxmox.nodes.return_value.qemu.return_value.status.current.get.return_value = {
         "status": "stopped"
     }
 
     with pytest.raises(ValueError, match="not running"):
-        await vm_console.execute_command("node1", "100", "ls -l")
+        asyncio.run(vm_console.execute_command("node1", "100", "ls -l"))
 
-@pytest.mark.asyncio
-async def test_execute_command_vm_not_found(vm_console, mock_proxmox):
+def test_execute_command_vm_not_found(vm_console, mock_proxmox):
     """Test command execution on non-existent VM."""
     mock_proxmox.nodes.return_value.qemu.return_value.status.current.get.side_effect = \
         Exception("VM not found")
 
     with pytest.raises(ValueError, match="not found"):
-        await vm_console.execute_command("node1", "100", "ls -l")
+        asyncio.run(vm_console.execute_command("node1", "100", "ls -l"))
 
-@pytest.mark.asyncio
-async def test_execute_command_failure(vm_console, mock_proxmox):
+def test_execute_command_failure(vm_console, mock_proxmox):
     """Test command execution failure."""
-    mock_proxmox.nodes.return_value.qemu.return_value.agent.exec.post.side_effect = \
-        Exception("Command failed")
+    mock_proxmox.exec_endpoint.post.side_effect = Exception("Command failed")
 
     with pytest.raises(RuntimeError, match="Failed to execute command"):
-        await vm_console.execute_command("node1", "100", "ls -l")
+        asyncio.run(vm_console.execute_command("node1", "100", "ls -l"))
 
-@pytest.mark.asyncio
-async def test_execute_command_with_error_output(vm_console, mock_proxmox):
+def test_execute_command_with_error_output(vm_console, mock_proxmox):
     """Test command execution with error output."""
-    mock_proxmox.nodes.return_value.qemu.return_value.agent.exec.post.return_value = {
-        "out": "",
-        "err": "command error",
-        "exitcode": 1
+    mock_proxmox.exec_status_endpoint.get.return_value = {
+        "out-data": "",
+        "err-data": "command error",
+        "exitcode": 1,
+        "exited": 1,
     }
 
-    result = await vm_console.execute_command("node1", "100", "invalid-command")
+    result = asyncio.run(vm_console.execute_command("node1", "100", "invalid-command"))
 
     assert result["success"] is True  # Success refers to API call, not command
     assert result["output"] == ""


### PR DESCRIPTION
## Summary
- restore the legacy `proxmox_mcp.tools.vm_console` import path expected by issue #11
- make `proxmox_mcp` lazily export `ProxmoxMCPServer` so tool imports do not require the full `mcp` server stack
- let `pytest tests/test_vm_console.py` run from the repo root by bootstrapping `src/` in tests and aligning the console tests with the current two-step guest-agent flow

## Validation
- `PYTHONPATH=src python -m pytest tests/test_vm_console.py -q`
- `PYTHONPATH=src python -c "import proxmox_mcp; from proxmox_mcp.tools.vm_console import VMConsoleManager; print('import_ok', proxmox_mcp.__version__, VMConsoleManager.__name__)"`

## Notes
- This is intentionally scoped to issue #11 and avoids the separate server/runtime lane already covered by open PR #12.